### PR TITLE
Feat/navigation pass query data

### DIFF
--- a/src/AvaloniaInside.Shell/DefaultNavigationUpdateStrategy.cs
+++ b/src/AvaloniaInside.Shell/DefaultNavigationUpdateStrategy.cs
@@ -10,110 +10,109 @@ namespace AvaloniaInside.Shell;
 
 public class DefaultNavigationUpdateStrategy : INavigationUpdateStrategy
 {
-    private readonly IPresenterProvider _presenterProvider;
+	private readonly IPresenterProvider _presenterProvider;
 
-    public DefaultNavigationUpdateStrategy(IPresenterProvider presenterProvider)
-    {
-        _presenterProvider = presenterProvider;
-    }
+	public DefaultNavigationUpdateStrategy(IPresenterProvider presenterProvider)
+	{
+		_presenterProvider = presenterProvider;
+	}
 
-    public event EventHandler<HostItemChangeEventArgs>? HostItemChanged;
+	public event EventHandler<HostItemChangeEventArgs>? HostItemChanged;
 
-    public async Task UpdateChangesAsync(
-        ShellView shellView,
-        NavigationStackChanges changes,
-        List<object> newInstances,
-        NavigateType navigateType,
-        object? argument,
-        bool hasArgument,
-        CancellationToken cancellationToken)
-    {
-        var isSame = changes.Previous == changes.Front;
+	public async Task UpdateChangesAsync(
+		ShellView shellView,
+		NavigationStackChanges changes,
+		List<object> newInstances,
+		NavigateType navigateType,
+		object? argument,
+		bool hasArgument,
+		CancellationToken cancellationToken)
+	{
+		var isSame = changes.Previous == changes.Front;
 
-        foreach (var instance in newInstances)
-        {
-            if (instance is INavigationLifecycle navigationLifecycle)
-                await navigationLifecycle.InitialiseAsync(cancellationToken);
+		foreach (var instance in newInstances)
+		{
+			if (instance is INavigationLifecycle navigationLifecycle)
+				await navigationLifecycle.InitialiseAsync(cancellationToken);
 
-            SubscribeForUpdateIfNeeded(instance);
-        }
+			SubscribeForUpdateIfNeeded(instance);
+		}
 
-        if (changes.Previous?.Instance is INavigationLifecycle oldInstanceLifecycle && !isSame)
-            await oldInstanceLifecycle.DisappearAsync(cancellationToken);
+		if (changes.Previous?.Instance is INavigationLifecycle oldInstanceLifecycle && !isSame)
+			await oldInstanceLifecycle.DisappearAsync(cancellationToken);
 
-        if (changes.Removed != null)
-            await InvokeRemoveAsync(shellView, changes.Removed, changes.Previous, navigateType, cancellationToken);
+		if (changes.Removed != null)
+			await InvokeRemoveAsync(shellView, changes.Removed, changes.Previous, navigateType, cancellationToken);
 
-        if (changes.Front?.Instance is INavigationLifecycle newInstanceLifecycle)
-        {
-            if (!isSame)
-                await newInstanceLifecycle.AppearAsync(cancellationToken);
+		if (changes.Front?.Instance is INavigationLifecycle newInstanceLifecycle)
+		{
+			if (!isSame)
+				await newInstanceLifecycle.AppearAsync(cancellationToken);
 
-            if (hasArgument)
-                await newInstanceLifecycle.ArgumentAsync(argument, cancellationToken);
+			if (hasArgument)
+				await newInstanceLifecycle.ArgumentAsync(argument, cancellationToken);
+			
+			var hasQuery = !string.IsNullOrWhiteSpace(changes.Front.Uri.Query);
+			if (hasQuery && (changes.Front.Instance as Control)?.DataContext is IQueryAttributable queryAttributable)
+			{
+				var query = changes.Front.Uri.Query;
 
-            var hasQuery = !string.IsNullOrWhiteSpace(changes.Front.Uri.Query);
-            if (hasQuery && (changes.Front.Instance as Control)?.DataContext is IQueryAttributable queryAttributable)
-            {
-                var query = changes.Front.Uri.Query;
+				var queryDict = query
+					.TrimStart('?')
+					.Split('&')
+					.Select(x => x.Split('='))
+					.Where(x => x.Length == 2)
+					.ToDictionary(x => x[0], x => (object) x[1]);
 
-                var queryDict = query
-                    .TrimStart('?')
-                    .Split('&')
-                    .Select(x => x.Split('='))
-                    .Where(x => x.Length == 2)
-                    .ToDictionary(x => x[0], x => (object) x[1]);
+				queryAttributable.ApplyQueryAttributes(queryDict);
+			}
+		}
 
-                queryAttributable.ApplyQueryAttributes(queryDict);
-            }
-        }
+		if (!isSame && changes.Front != null)
+			await _presenterProvider.For(navigateType).PresentAsync(shellView, changes.Front, navigateType, cancellationToken);
+	}
 
-        if (!isSame && changes.Front != null)
-            await _presenterProvider.For(navigateType)
-                .PresentAsync(shellView, changes.Front, navigateType, cancellationToken);
-    }
-
-    private async Task InvokeRemoveAsync(ShellView shellView,
+	private async Task InvokeRemoveAsync(ShellView shellView,
         IList<NavigationChain> removed,
         NavigationChain? previous,
         NavigateType navigateType,
         CancellationToken cancellationToken)
-    {
-        var presenter = _presenterProvider.Remove();
-        foreach (var chain in removed)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (previous == chain)
-                await _presenterProvider.Remove().PresentAsync(shellView, previous, navigateType, cancellationToken);
-            else
-                await presenter.PresentAsync(shellView, chain, navigateType, cancellationToken);
+	{
+		var presenter = _presenterProvider.Remove();
+		foreach (var chain in removed)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (previous == chain)
+				await _presenterProvider.Remove().PresentAsync(shellView, previous, navigateType, cancellationToken);
+			else
+				await presenter.PresentAsync(shellView, chain, navigateType, cancellationToken);
 
-            if (chain.Instance is INavigationLifecycle lifecycle)
-                await lifecycle.TerminateAsync(cancellationToken);
+			if (chain.Instance is INavigationLifecycle lifecycle)
+				await lifecycle.TerminateAsync(cancellationToken);
 
-            UnSubscribeForUpdateIfNeeded(chain.Instance);
-        }
-    }
+			UnSubscribeForUpdateIfNeeded(chain.Instance);
+		}
+	}
 
-    private void SubscribeForUpdateIfNeeded(object? instance)
-    {
-        if (instance is not SelectingItemsControl selectingItemsControl) return;
-        selectingItemsControl.SelectionChanged += SelectingItemsControlOnSelectionChanged;
-    }
+	private void SubscribeForUpdateIfNeeded(object? instance)
+	{
+		if (instance is not SelectingItemsControl selectingItemsControl) return;
+		selectingItemsControl.SelectionChanged += SelectingItemsControlOnSelectionChanged;
+	}
 
-    private void UnSubscribeForUpdateIfNeeded(object instance)
-    {
-        if (instance is not SelectingItemsControl selectingItemsControl) return;
-        selectingItemsControl.SelectionChanged -= SelectingItemsControlOnSelectionChanged;
-    }
+	private void UnSubscribeForUpdateIfNeeded(object instance)
+	{
+		if (instance is not SelectingItemsControl selectingItemsControl) return;
+		selectingItemsControl.SelectionChanged -= SelectingItemsControlOnSelectionChanged;
+	}
 
-    private void SelectingItemsControlOnSelectionChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (e.AddedItems?.Count > 0 && e.AddedItems[0] is NavigationChain chain)
-        {
-            HostItemChanged?.Invoke(this, new HostItemChangeEventArgs(
-                e.RemovedItems?.Count > 0 ? e.RemovedItems[0] as NavigationChain : null,
-                chain));
-        }
-    }
+	private void SelectingItemsControlOnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+	{
+		if (e.AddedItems?.Count > 0 && e.AddedItems[0] is NavigationChain chain)
+		{
+			HostItemChanged?.Invoke(this, new HostItemChangeEventArgs(
+				e.RemovedItems?.Count > 0 ? e.RemovedItems[0] as NavigationChain : null,
+				chain));
+		}
+	}
 }

--- a/src/AvaloniaInside.Shell/DefaultNavigationUpdateStrategy.cs
+++ b/src/AvaloniaInside.Shell/DefaultNavigationUpdateStrategy.cs
@@ -52,19 +52,19 @@ public class DefaultNavigationUpdateStrategy : INavigationUpdateStrategy
 			if (hasArgument)
 				await newInstanceLifecycle.ArgumentAsync(argument, cancellationToken);
 			
-			var hasQuery = !string.IsNullOrWhiteSpace(changes.Front.Uri.Query);
+			var hasQuery = !string.IsNullOrWhiteSpace(changes.Front?.Uri?.Query);
 			if (hasQuery && (changes.Front.Instance as Control)?.DataContext is IQueryAttributable queryAttributable)
 			{
 				var query = changes.Front.Uri.Query;
 
-				var queryDict = query
+				var queryDict = query?
 					.TrimStart('?')
 					.Split('&')
 					.Select(x => x.Split('='))
 					.Where(x => x.Length == 2)
 					.ToDictionary(x => x[0], x => (object) x[1]);
-
-				queryAttributable.ApplyQueryAttributes(queryDict);
+				if(queryDict != null)
+					queryAttributable.ApplyQueryAttributes(queryDict);
 			}
 		}
 

--- a/src/AvaloniaInside.Shell/DefaultNavigationUpdateStrategy.cs
+++ b/src/AvaloniaInside.Shell/DefaultNavigationUpdateStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -9,94 +10,110 @@ namespace AvaloniaInside.Shell;
 
 public class DefaultNavigationUpdateStrategy : INavigationUpdateStrategy
 {
-	private readonly IPresenterProvider _presenterProvider;
+    private readonly IPresenterProvider _presenterProvider;
 
-	public DefaultNavigationUpdateStrategy(IPresenterProvider presenterProvider)
-	{
-		_presenterProvider = presenterProvider;
-	}
+    public DefaultNavigationUpdateStrategy(IPresenterProvider presenterProvider)
+    {
+        _presenterProvider = presenterProvider;
+    }
 
-	public event EventHandler<HostItemChangeEventArgs>? HostItemChanged;
+    public event EventHandler<HostItemChangeEventArgs>? HostItemChanged;
 
-	public async Task UpdateChangesAsync(
-		ShellView shellView,
-		NavigationStackChanges changes,
-		List<object> newInstances,
-		NavigateType navigateType,
-		object? argument,
-		bool hasArgument,
-		CancellationToken cancellationToken)
-	{
-		var isSame = changes.Previous == changes.Front;
+    public async Task UpdateChangesAsync(
+        ShellView shellView,
+        NavigationStackChanges changes,
+        List<object> newInstances,
+        NavigateType navigateType,
+        object? argument,
+        bool hasArgument,
+        CancellationToken cancellationToken)
+    {
+        var isSame = changes.Previous == changes.Front;
 
-		foreach (var instance in newInstances)
-		{
-			if (instance is INavigationLifecycle navigationLifecycle)
-				await navigationLifecycle.InitialiseAsync(cancellationToken);
+        foreach (var instance in newInstances)
+        {
+            if (instance is INavigationLifecycle navigationLifecycle)
+                await navigationLifecycle.InitialiseAsync(cancellationToken);
 
-			SubscribeForUpdateIfNeeded(instance);
-		}
+            SubscribeForUpdateIfNeeded(instance);
+        }
 
-		if (changes.Previous?.Instance is INavigationLifecycle oldInstanceLifecycle && !isSame)
-			await oldInstanceLifecycle.DisappearAsync(cancellationToken);
+        if (changes.Previous?.Instance is INavigationLifecycle oldInstanceLifecycle && !isSame)
+            await oldInstanceLifecycle.DisappearAsync(cancellationToken);
 
-		if (changes.Removed != null)
-			await InvokeRemoveAsync(shellView, changes.Removed, changes.Previous, navigateType, cancellationToken);
+        if (changes.Removed != null)
+            await InvokeRemoveAsync(shellView, changes.Removed, changes.Previous, navigateType, cancellationToken);
 
-		if (changes.Front?.Instance is INavigationLifecycle newInstanceLifecycle)
-		{
-			if (!isSame)
-				await newInstanceLifecycle.AppearAsync(cancellationToken);
+        if (changes.Front?.Instance is INavigationLifecycle newInstanceLifecycle)
+        {
+            if (!isSame)
+                await newInstanceLifecycle.AppearAsync(cancellationToken);
 
-			if (hasArgument)
-				await newInstanceLifecycle.ArgumentAsync(argument, cancellationToken);
-		}
+            if (hasArgument)
+                await newInstanceLifecycle.ArgumentAsync(argument, cancellationToken);
 
-		if (!isSame && changes.Front != null)
-			await _presenterProvider.For(navigateType).PresentAsync(shellView, changes.Front, navigateType, cancellationToken);
-	}
+            var hasQuery = !string.IsNullOrWhiteSpace(changes.Front.Uri.Query);
+            if (hasQuery && (changes.Front.Instance as Control)?.DataContext is IQueryAttributable queryAttributable)
+            {
+                var query = changes.Front.Uri.Query;
 
-	private async Task InvokeRemoveAsync(ShellView shellView,
+                var queryDict = query
+                    .TrimStart('?')
+                    .Split('&')
+                    .Select(x => x.Split('='))
+                    .Where(x => x.Length == 2)
+                    .ToDictionary(x => x[0], x => (object) x[1]);
+
+                queryAttributable.ApplyQueryAttributes(queryDict);
+            }
+        }
+
+        if (!isSame && changes.Front != null)
+            await _presenterProvider.For(navigateType)
+                .PresentAsync(shellView, changes.Front, navigateType, cancellationToken);
+    }
+
+    private async Task InvokeRemoveAsync(ShellView shellView,
         IList<NavigationChain> removed,
         NavigationChain? previous,
         NavigateType navigateType,
         CancellationToken cancellationToken)
-	{
-		var presenter = _presenterProvider.Remove();
-		foreach (var chain in removed)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			if (previous == chain)
-				await _presenterProvider.Remove().PresentAsync(shellView, previous, navigateType, cancellationToken);
-			else
-				await presenter.PresentAsync(shellView, chain, navigateType, cancellationToken);
+    {
+        var presenter = _presenterProvider.Remove();
+        foreach (var chain in removed)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (previous == chain)
+                await _presenterProvider.Remove().PresentAsync(shellView, previous, navigateType, cancellationToken);
+            else
+                await presenter.PresentAsync(shellView, chain, navigateType, cancellationToken);
 
-			if (chain.Instance is INavigationLifecycle lifecycle)
-				await lifecycle.TerminateAsync(cancellationToken);
+            if (chain.Instance is INavigationLifecycle lifecycle)
+                await lifecycle.TerminateAsync(cancellationToken);
 
-			UnSubscribeForUpdateIfNeeded(chain.Instance);
-		}
-	}
+            UnSubscribeForUpdateIfNeeded(chain.Instance);
+        }
+    }
 
-	private void SubscribeForUpdateIfNeeded(object? instance)
-	{
-		if (instance is not SelectingItemsControl selectingItemsControl) return;
-		selectingItemsControl.SelectionChanged += SelectingItemsControlOnSelectionChanged;
-	}
+    private void SubscribeForUpdateIfNeeded(object? instance)
+    {
+        if (instance is not SelectingItemsControl selectingItemsControl) return;
+        selectingItemsControl.SelectionChanged += SelectingItemsControlOnSelectionChanged;
+    }
 
-	private void UnSubscribeForUpdateIfNeeded(object instance)
-	{
-		if (instance is not SelectingItemsControl selectingItemsControl) return;
-		selectingItemsControl.SelectionChanged -= SelectingItemsControlOnSelectionChanged;
-	}
+    private void UnSubscribeForUpdateIfNeeded(object instance)
+    {
+        if (instance is not SelectingItemsControl selectingItemsControl) return;
+        selectingItemsControl.SelectionChanged -= SelectingItemsControlOnSelectionChanged;
+    }
 
-	private void SelectingItemsControlOnSelectionChanged(object? sender, SelectionChangedEventArgs e)
-	{
-		if (e.AddedItems?.Count > 0 && e.AddedItems[0] is NavigationChain chain)
-		{
-			HostItemChanged?.Invoke(this, new HostItemChangeEventArgs(
-				e.RemovedItems?.Count > 0 ? e.RemovedItems[0] as NavigationChain : null,
-				chain));
-		}
-	}
+    private void SelectingItemsControlOnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (e.AddedItems?.Count > 0 && e.AddedItems[0] is NavigationChain chain)
+        {
+            HostItemChanged?.Invoke(this, new HostItemChangeEventArgs(
+                e.RemovedItems?.Count > 0 ? e.RemovedItems[0] as NavigationChain : null,
+                chain));
+        }
+    }
 }

--- a/src/AvaloniaInside.Shell/IQueryAttributable.cs
+++ b/src/AvaloniaInside.Shell/IQueryAttributable.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace AvaloniaInside.Shell;
+
+public interface IQueryAttributable
+{
+    void ApplyQueryAttributes(IDictionary<string, object> query);
+}

--- a/src/Example/ShellExample/ShellExample/ViewModels/SecondViewModel.cs
+++ b/src/Example/ShellExample/ShellExample/ViewModels/SecondViewModel.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using AvaloniaInside.Shell;
+using ReactiveUI;
+
+namespace ShellExample.ViewModels;
+
+public class SecondViewModel : ViewModelBase, IQueryAttributable
+{
+    private string _name;
+
+    public string Name
+    {
+        get => _name;
+        set => this.RaiseAndSetIfChanged(ref _name, value);
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        query.TryGetValue(nameof(Name),out var nameValue);
+        Name = nameValue?.ToString();
+    }
+}

--- a/src/Example/ShellExample/ShellExample/Views/HomePage.axaml
+++ b/src/Example/ShellExample/ShellExample/Views/HomePage.axaml
@@ -12,7 +12,7 @@
 
 		<Button HorizontalAlignment="Center"
 				Content="Click on me"
-				Navigator.To="/second"
+				Navigator.To="/second?Name=ShellExample"
 				CommandParameter="Hello Parameters"></Button>
 
 		<Button HorizontalAlignment="Center" Content="Show dialog" Command="{Binding ShowDialogCommand}"></Button>

--- a/src/Example/ShellExample/ShellExample/Views/SecondView.axaml
+++ b/src/Example/ShellExample/ShellExample/Views/SecondView.axaml
@@ -1,11 +1,19 @@
 <Page xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="ShellExample.Views.SecondView"
-             NavigationBar.Header="Second view"
-			 Background="Black">
-	Welcome to Avalonia!
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:viewModels="clr-namespace:ShellExample.ViewModels"
+      mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+      x:Class="ShellExample.Views.SecondView"
+      NavigationBar.Header="Second view"
+      x:DataType="viewModels:SecondViewModel"
+      Background="Black">
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="20">
+        <TextBlock>
+            Welcome to Avalonia!
+        </TextBlock>
+        
+        <TextBlock Text="{Binding Name}" />
+        
+    </StackPanel>
 </Page>
-

--- a/src/Example/ShellExample/ShellExample/Views/SecondView.axaml.cs
+++ b/src/Example/ShellExample/ShellExample/Views/SecondView.axaml.cs
@@ -1,6 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using AvaloniaInside.Shell;
+using ShellExample.ViewModels;
 
 namespace ShellExample.Views;
 
@@ -14,6 +17,12 @@ public partial class SecondView : Page
 	private void InitializeComponent()
 	{
 		AvaloniaXamlLoader.Load(this);
+	}
+
+	public override Task InitialiseAsync(CancellationToken cancellationToken)
+	{
+		DataContext = new SecondViewModel();
+		return base.InitialiseAsync(cancellationToken);
 	}
 }
 


### PR DESCRIPTION
Based on issues in https://github.com/AvaloniaInside/Shell/issues/11#issue-1902105864
Based on the discussion in https://github.com/AvaloniaInside/Shell/pull/12#issue-1904038811

I think that the addition of the "pass query string" function to the `DefaultNavigationUpdateStrategy` is a good idea. This function plays a fundamental role in navigating within the shell.
