### PR TITLE
Fix route not found with upper char

### DIFF
--- a/src/AvaloniaInside.Shell/NavigationRegistrar.cs
+++ b/src/AvaloniaInside.Shell/NavigationRegistrar.cs
@@ -57,5 +57,5 @@ public class NavigationRegistrar : INavigationRegistrar
 	}
 
 	public bool TryGetNode(string path, out NavigationNode node) =>
-		Navigations.TryGetValue(path, out node);
+		Navigations.TryGetValue(path.ToLower(), out node);
 }


### PR DESCRIPTION
**Problem:**
Routes with Uppercase char's not working.

**Detected Issue:**
On [NavigationRegistrar.RegisterRoute](https://github.com/AvaloniaInside/Shell/blob/faf9bc72125be6af3f53325d26578342572f57fc/src/AvaloniaInside.Shell/NavigationRegistrar.cs#L30) the route is registered with `route.ToLower()`, on [NavigationRegistrar.TryGetNode](https://github.com/AvaloniaInside/Shell/blob/faf9bc72125be6af3f53325d26578342572f57fc/src/AvaloniaInside.Shell/NavigationRegistrar.cs#L60) it is called without `ToLower()`.

**Solution**
Call `Navigations.TryGetValue(path, out node);` with `path.ToLower()` in NavigationRegistrar