### PR TITLE
Add ability to provide a custom INavigationViewLocator so other OIC c…

### DIFF
--- a/src/AvaloniaInside.Shell/AppBuilderExtensions.cs
+++ b/src/AvaloniaInside.Shell/AppBuilderExtensions.cs
@@ -18,11 +18,7 @@ public static class AppBuilderExtensions
 			Locator.CurrentMutable.Register<INavigationRegistrar, NavigationRegistrar>();
 			Locator.CurrentMutable.Register<IPresenterProvider, PresenterProvider>();
 
-			if (viewLocatorFactory != null)
-			{
-				Locator.CurrentMutable.Register(viewLocatorFactory, typeof(INavigationViewLocator));
-			}
-			else
+			if (viewLocatorFactory is null)
 			{
 				Locator.CurrentMutable.Register<INavigationViewLocator, DefaultNavigationViewLocator>();
 			}
@@ -32,12 +28,14 @@ public static class AppBuilderExtensions
 
 			Locator.CurrentMutable.Register<INavigator>(() =>
 			{
+				var viewLocator = viewLocatorFactory != null ? viewLocatorFactory.Invoke() : Locator.Current.GetService<INavigationViewLocator>()!;
 				var registrar = Locator.Current.GetService<INavigationRegistrar>()!;
 				return new Navigator(
 					registrar,
 					new RelativeNavigateStrategy(registrar),
 					Locator.Current.GetService<INavigationUpdateStrategy>()!,
-					Locator.Current.GetService<INavigationViewLocator>()!);
+					viewLocator
+					);
 			});
 		});
 


### PR DESCRIPTION
Add ability to provide a custom INavigationViewLocator so other OIC containers can be used to create views.

Now the UseShell extension method can receive a Func<INavigationViewLocator> factory function to provide a custom view locator. 

This is useful in cases such as custom view locators from the target project. 

Also a DelegateNavigationViewLocator was created to simplify the INavigationViewLocator implementation. 

How to used?

Imagine we have implemented a custom view locator using MSDI package or CommunityToolkit.Mvvm.DependencyInjection, 
Then we can just replace the default INavigationViewLocator like this. 
```csharp
      app.UseShell(()=>  new CustomNavigationViewLocator());
```
or for CummunityToolkit.Mvvm.DependencyInjection
```csharp
      app.UseShell(()=> Ioc.Default.GetRequriedService<INavigationViewLocator>());
````
or for delegate view creation
```csharp
      app.UseShell((node)=> Activator.CreateInstance(node.Page));
```