### PR TITLE
#59 - added Locator.RegisterResolverCallbackChanged to support Splat'…

### DIFF
--- a/src/AvaloniaInside.Shell/AppBuilderExtensions.cs
+++ b/src/AvaloniaInside.Shell/AppBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace AvaloniaInside.Shell;
 public static class AppBuilderExtensions
 {
 	public static AppBuilder UseShell(this AppBuilder builder, Func<INavigationViewLocator>? viewLocatorFactory = null) =>
-		builder.AfterPlatformServicesSetup(_ =>
+		builder.AfterPlatformServicesSetup(_ => Locator.RegisterResolverCallbackChanged(() =>
 		{
 			if (Locator.CurrentMutable is null)
 			{
@@ -37,7 +37,7 @@ public static class AppBuilderExtensions
 					viewLocator
 					);
 			});
-		});
+		}));
 
 	public static AppBuilder UseShell(this AppBuilder builder, Func<NavigationNode, object> viewFactory)
 		=> builder.UseShell(() => new DelegateNavigationViewLocator(viewFactory));


### PR DESCRIPTION
…s Locator being changed to some other DI framework

Note: Calling `Locator.RegisterREsolverCallbackChanged` will call this callback upon registration anyways to ensure that the code is run even if the Locator is never changed!

We essentially copied this approach from ReactiveUI [as can be seen here](https://github.com/AvaloniaUI/Avalonia/blob/f4633e210c23ff7fbaec3cf402d03deac5315a68/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs#L16)