### PR TITLE
- NavigateResult is now testable

### DIFF
--- a/src/AvaloniaInside.Shell/NavigateResult.cs
+++ b/src/AvaloniaInside.Shell/NavigateResult.cs
@@ -12,4 +12,10 @@ public class NavigateResult
 	public object? Argument { get; }
 
 	public T? As<T>() => HasArgument && Argument is T argument ? argument : default;
+	
+	public static NavigateResult FromResult<T>(T argument) => 	new(true, argument);
+
+	public static readonly NavigateResult Completed = new NavigateResult(false, null);
 }
+
+


### PR DESCRIPTION
Using the newly added static method and field, the test can be written like:

```

    /// <summary>
    /// Tests the navigation flow when user fails login first time but succeeds second time.
    /// </summary>
    [Test]
    public async Task NavigateToFirstViewAsync_WhenNotLoggedIn_SuccessfulLoginSecondTry()
    {
        // Arrange
        _sessionMock.Setup(x => x.IsLoggedIn).Returns(false);
        var failedLoginResult = NavigateResult.FromResult(new LoginResult("damn..."));
        var successLoginResult = NavigateResult.FromResult(new LoginResult(new ClaimsPrincipal()));

        _navigatorMock.SetupSequence(x => x.NavigateAndWaitAsync("/login", NavigateType.Modal, It.IsAny<CancellationToken>()))
                      .ReturnsAsync(failedLoginResult)
                      .ReturnsAsync(successLoginResult);

        // Act
        await _strategy.NavigateToFirstViewAsync();

        // Assert
        _navigatorMock.Verify(x => x.NavigateAsync("/splash", NavigateType.Normal, It.IsAny<CancellationToken>()), Times.Once);
        _navigatorMock.Verify(x => x.NavigateAndWaitAsync("/login", NavigateType.Modal, It.IsAny<CancellationToken>()), Times.Exactly(2));
        _navigatorMock.Verify(x => x.NavigateAsync("/main", NavigateType.ReplaceRoot, It.IsAny<CancellationToken>()), Times.Once);
    }


```