### PR TITLE
Update Avalonia.ReactiveUI to ReactiveUI.Avalonia

### DIFF
--- a/src/AvaloniaInside.Shell/AvaloniaInside.Shell.csproj
+++ b/src/AvaloniaInside.Shell/AvaloniaInside.Shell.csproj
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Avalonia" />
 		<PackageReference Include="Avalonia.Themes.Fluent" />
-		<PackageReference Include="Avalonia.ReactiveUI" />
+		<PackageReference Include="ReactiveUI.Avalonia" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
 	</ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,13 +10,13 @@
 		<PackageVersion Include="Avalonia.iOS" Version="11.3.9" />
 		<PackageVersion Include="Avalonia.Browser" Version="11.3.9" />
 		<PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.9" />
-		<PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.9" />
+		<PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8" />
 		<PackageVersion Include="Avalonia.Diagnostics" Version="11.3.9" />
 		<PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.9" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageVersion Include="Projektanker.Icons.Avalonia" Version="9.6.2" />
 		<PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2" />
 		<PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.17" />
-		<PackageVersion Include="ReactiveUI" Version="21.0.1" />
+		<PackageVersion Include="ReactiveUI" Version="22.2.1" />
 	</ItemGroup>
 </Project>

--- a/src/Example/ShellBottomCustomNavigator/ShellBottomCustomNavigator.Desktop/Program.cs
+++ b/src/Example/ShellBottomCustomNavigator/ShellBottomCustomNavigator.Desktop/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.ReactiveUI;
 using AvaloniaInside.Shell;
 
 namespace ShellBottomCustomNavigator.Desktop;
@@ -20,6 +19,5 @@ sealed class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
-            .UseReactiveUI()
             .UseShell();
 }

--- a/src/Example/ShellBottomCustomNavigator/ShellBottomCustomNavigator/ShellBottomCustomNavigator.csproj
+++ b/src/Example/ShellBottomCustomNavigator/ShellBottomCustomNavigator/ShellBottomCustomNavigator.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Avalonia" />
         <PackageReference Include="Avalonia.Themes.Fluent" />
         <PackageReference Include="Avalonia.Fonts.Inter" />
-        <PackageReference Include="Avalonia.ReactiveUI" />
+        <PackageReference Include="ReactiveUI.Avalonia" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
         <PackageReference Include="Newtonsoft.Json" />

--- a/src/Example/ShellExample/ShellExample.Desktop/Program.cs
+++ b/src/Example/ShellExample/ShellExample.Desktop/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.ReactiveUI;
 using AvaloniaInside.Shell;
 
 namespace ShellExample.Desktop;
@@ -19,6 +18,5 @@ class Program
 		=> AppBuilder.Configure<App>()
 			.UsePlatformDetect()
 			.LogToTrace()
-			.UseReactiveUI()
 			.UseShell();
 }

--- a/src/Example/ShellExample/ShellExample/ShellExample.csproj
+++ b/src/Example/ShellExample/ShellExample/ShellExample.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Avalonia" />
         <PackageReference Include="Avalonia.Themes.Fluent" />
-        <PackageReference Include="Avalonia.ReactiveUI" />
+        <PackageReference Include="ReactiveUI.Avalonia" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics" />
         <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
Due to [AvaloniaUI/Avalonia/issues/19601](Splat issue) there is a need to replace Avalonia.ReactiveUI with ReactiveUI.Avalonia in newer version of Avalonia.