### PR TITLE
Update README with migration advice for Avalonia 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## IMPORTANT: WE STOP HERE!
+
+## Thanks to [@jsuarezruiz](https://github.com/jsuarezruiz) Avalonia 12 released native controls and I highly recommended to migrate you exists code to native controls from Avalonia.
+https://github.com/AvaloniaUI/Avalonia/pull/20794
+
 ![image](https://github.com/AvaloniaInside/Shell/assets/956077/656b77bc-f7bf-4d24-96f4-00d201bb78e0)
 
 <h1><img src="https://github.com/AvaloniaInside/Shell/assets/956077/6b34f130-0297-4530-ab0d-4074e92dae21" width="86" /> Shell</h1>


### PR DESCRIPTION
Added a note about migrating to native controls in Avalonia 12.

https://github.com/AvaloniaUI/Avalonia/pull/20794

Thanks to @jsuarezruiz